### PR TITLE
Fixed Long product name overlaps with product icon and moves other title

### DIFF
--- a/presentation/src/main/res/layout/item_vouchers_list.xml
+++ b/presentation/src/main/res/layout/item_vouchers_list.xml
@@ -39,13 +39,17 @@
         <io.forus.me.android.presentation.view.component.text.TextView
             android:id="@+id/name"
             style="@style/CardTitle4"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/logo"
+            android:layout_marginEnd="8dp"
             android:layout_marginTop="24dp"
+            android:maxLines="1"
+            android:ellipsize="end"
             app:type="medium"
-            tools:text="Kindpakket" />
+            tools:text="Kindpakket very very super long vouchers title , more then twoo lines " />
 
         <io.forus.me.android.presentation.view.component.text.TextView
             android:id="@+id/organization_name"


### PR DESCRIPTION
Issue reference:
[](https://github.com/teamforus/APP-2023-make-me-app-great-again/issues/89)