### PR TITLE
Fix permission request loop for camera access when permissions are denied permanently

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,8 @@ allprojects {
 
   }
   ext {
-    androidVersionCode = 65
-    androidVersionName = "0.5.5"
+    androidVersionCode = 67
+    androidVersionName = "0.5.6"
     androidBuildNumber = 1
     testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
     testApplicationId = 'io.forus.me.test'

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -73,6 +73,7 @@
         <activity
             android:name=".view.screens.main.MainActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/presentation/src/main/java/io/forus/me/android/presentation/AndroidApplication.kt
+++ b/presentation/src/main/java/io/forus/me/android/presentation/AndroidApplication.kt
@@ -16,6 +16,8 @@ import com.google.firebase.firestore.FirebaseFirestoreSettings
 import com.google.firebase.storage.FirebaseStorage
 import io.forus.me.android.data.net.MeServiceFactory
 import io.forus.me.android.presentation.api_config.ApiConfig
+import io.forus.me.android.presentation.api_config.ApiType
+import io.forus.me.android.presentation.helpers.SharedPref
 import io.forus.me.android.presentation.internal.Injection
 
 /**
@@ -43,6 +45,19 @@ class AndroidApplication : Application() {
         this.initFirebase()
 
         this.me = this
+
+        SharedPref.init(this)
+        if (!BuildConfig.APPLICATION_ID.equals("io.forus.me")) {
+            val savedApiOption = SharedPref.read(SharedPref.OPTION_API_TYPE,"") ?: ""
+            if (savedApiOption.isNotEmpty()) {
+                val apiType = ApiConfig.stringToApiType(savedApiOption)
+                if (apiType == ApiType.OTHER) {
+                    ApiConfig.changeToCustomApi(SharedPref.read(SharedPref.OPTION_CUSTOM_API_URL, BuildConfig.SERVER_URL))
+                } else {
+                    ApiConfig.changeApi(apiType)
+                }
+            }
+        }
 
     }
 

--- a/presentation/src/main/java/io/forus/me/android/presentation/view/screens/dashboard/DashboardActivity.kt
+++ b/presentation/src/main/java/io/forus/me/android/presentation/view/screens/dashboard/DashboardActivity.kt
@@ -26,6 +26,7 @@ import io.reactivex.schedulers.Schedulers
 class DashboardActivity : AppCompatActivity() {
 
      val viewModel: VoucherViewModel by viewModels()
+    private val db = Injection.instance.databaseHelper
 
     val systemServices by lazy(LazyThreadSafetyMode.NONE) { SystemServices(this) }
     val navigator by lazy { Navigator() }
@@ -52,9 +53,11 @@ class DashboardActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         val binding = ActivityDashboardBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+
+        db.open("") //Database initialization
 
         val navigationHost =
             supportFragmentManager.findFragmentById(R.id.fragment_container) as NavHostFragment
@@ -92,6 +95,8 @@ class DashboardActivity : AppCompatActivity() {
             loggingViewModel.authorizeFirestore()
         },100)
     }
+
+
 
     fun navigateToQrScanner() {
         this.navigator.navigateToQrScanner(this)

--- a/presentation/src/main/java/io/forus/me/android/presentation/view/screens/dashboard/DashboardActivity.kt
+++ b/presentation/src/main/java/io/forus/me/android/presentation/view/screens/dashboard/DashboardActivity.kt
@@ -19,6 +19,7 @@ import io.forus.me.android.presentation.internal.Injection
 import io.forus.me.android.presentation.navigation.Navigator
 import io.forus.me.android.presentation.view.MeBottomSheetDialogFragment
 import io.forus.me.android.presentation.view.fragment.QrFragment
+import io.forus.me.android.presentation.view.screens.main.MainActivity
 import io.forus.me.android.presentation.view.screens.vouchers.VoucherViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
@@ -57,7 +58,11 @@ class DashboardActivity : AppCompatActivity() {
         setContentView(binding.root)
 
 
-        db.open("") //Database initialization
+        if(!db.isOpen){
+            startActivity(Intent(this, MainActivity::class.java))
+            finish()
+        }
+
 
         val navigationHost =
             supportFragmentManager.findFragmentById(R.id.fragment_container) as NavHostFragment

--- a/presentation/src/main/java/io/forus/me/android/presentation/view/screens/main/MainActivity.kt
+++ b/presentation/src/main/java/io/forus/me/android/presentation/view/screens/main/MainActivity.kt
@@ -31,32 +31,11 @@ class MainActivity : BaseActivity() {
     private val db = Injection.instance.databaseHelper
     private val settings = Injection.instance.settingsDataSource
 
-    var PACKAGE_NAME: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(io.forus.me.android.presentation.R.layout.activity_main)
 
-        PACKAGE_NAME = applicationContext.packageName
-
-        SharedPref.init(this@MainActivity)
-
-
-
-
-        if (!BuildConfig.APPLICATION_ID.equals("io.forus.me")) {
-            val savedApiOption = SharedPref.read(SharedPref.OPTION_API_TYPE,"") ?: ""
-            if (savedApiOption.isNotEmpty()) {
-                val apiType = ApiConfig.stringToApiType(savedApiOption)
-                if (apiType == ApiType.OTHER) {
-                    ApiConfig.changeToCustomApi(SharedPref.read(SharedPref.OPTION_CUSTOM_API_URL, BuildConfig.SERVER_URL))
-                } else {
-                    ApiConfig.changeApi(apiType)
-                }
-            }
-        }
-
-        val isGooglePlayAvailable = checkPlayServices()
 
         //Check inApp update
         h.postDelayed({
@@ -70,7 +49,6 @@ class MainActivity : BaseActivity() {
             } else {
                 navigateToDashboard()
             }
-
 
             settings.getFCMToken()
 
@@ -110,7 +88,7 @@ class MainActivity : BaseActivity() {
      * Goes to the dashboard screen.
      */
     private fun navigateToDashboard() {
-        db.open("")
+
         this.navigator.navigateToDashboard(this)
         finish()
     }
@@ -145,7 +123,7 @@ class MainActivity : BaseActivity() {
 
     val MY_REQUEST_CODE = 2514
 
-    var appUpdateManager: AppUpdateManager? = null
+    private var appUpdateManager: AppUpdateManager? = null
 
     private fun initInAppUpdate() {
 

--- a/presentation/src/main/java/io/forus/me/android/presentation/view/screens/main/MainActivity.kt
+++ b/presentation/src/main/java/io/forus/me/android/presentation/view/screens/main/MainActivity.kt
@@ -36,6 +36,23 @@ class MainActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
         setContentView(io.forus.me.android.presentation.R.layout.activity_main)
 
+        SharedPref.init(this@MainActivity)
+
+
+
+
+        if (!BuildConfig.APPLICATION_ID.equals("io.forus.me")) {
+            val savedApiOption = SharedPref.read(SharedPref.OPTION_API_TYPE,"") ?: ""
+            if (savedApiOption.isNotEmpty()) {
+                val apiType = ApiConfig.stringToApiType(savedApiOption)
+                if (apiType == ApiType.OTHER) {
+                    ApiConfig.changeToCustomApi(SharedPref.read(SharedPref.OPTION_CUSTOM_API_URL, BuildConfig.SERVER_URL))
+                } else {
+                    ApiConfig.changeApi(apiType)
+                }
+            }
+        }
+
 
         //Check inApp update
         h.postDelayed({
@@ -88,6 +105,8 @@ class MainActivity : BaseActivity() {
      * Goes to the dashboard screen.
      */
     private fun navigateToDashboard() {
+
+        db.open("")
 
         this.navigator.navigateToDashboard(this)
         finish()

--- a/presentation/src/main/res/values-nl/strings.xml
+++ b/presentation/src/main/res/values-nl/strings.xml
@@ -394,5 +394,7 @@
     <string name="transaction_note">Notitie</string>
     <string name="transaction_paid">Betaald</string>
 
+    <string name="qr_camera_permission_required">Cameratoegang is vereist om QR-codes te scannen.</string>
+    <string name="settings">Instellingen</string>
 
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -434,4 +434,7 @@
     <string name="transaction_note">Note</string>
     <string name="transaction_paid">Paid</string>
 
+    <string name="qr_camera_permission_required">Camera permission is required to scan QR codes.</string>
+    <string name="settings">Settings</string>
+
 </resources>


### PR DESCRIPTION
@lexlog  Resolved an issue where the app entered a loop in the camera permission request process when permissions were denied, especially when the user selected "Never ask again" or permanently blocked permission requests. Improved the permission request logic by adding checks to avoid unnecessary repeated requests. If permissions are disabled, the app now redirects the user to the settings. If the user does not grant access in settings, the app gracefully navigates back to the main screen.